### PR TITLE
Remove block patterns tag temporarily

### DIFF
--- a/assets/css/ie.css
+++ b/assets/css/ie.css
@@ -11,7 +11,7 @@ Version: 1.0.8
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: seedlet
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, block-patterns, block-styles, wide-blocks
+Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, block-styles, wide-blocks
 
 Seedlet WordPress Theme, (C) 2020 Automattic, Inc.
 Seedlet is distributed under the terms of the GNU GPL.

--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -11,7 +11,7 @@ Version: 1.0.8
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: seedlet
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, block-patterns, block-styles, wide-blocks
+Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, block-styles, wide-blocks
 
 Seedlet WordPress Theme, (C) 2020 Automattic, Inc.
 Seedlet is distributed under the terms of the GNU GPL.

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -11,7 +11,7 @@ Version: 1.0.8
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: seedlet
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, block-patterns, block-styles, wide-blocks
+Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, block-styles, wide-blocks
 
 Seedlet WordPress Theme, (C) 2020 Automattic, Inc.
 Seedlet is distributed under the terms of the GNU GPL.

--- a/style.css
+++ b/style.css
@@ -11,7 +11,7 @@ Version: 1.0.8
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: seedlet
-Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, block-patterns, block-styles, wide-blocks
+Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, block-styles, wide-blocks
 
 Seedlet WordPress Theme, (C) 2020 Automattic, Inc.
 Seedlet is distributed under the terms of the GNU GPL.


### PR DESCRIPTION
ThemeCheck in the .org repository is currently blocking uploads that use the `block-patterns` theme tag. 

Since we've been waiting for a week for that to be fixed, I suggest we remove it for the 1.0.8 release, and include this tag in the next release instead. That way we can get this update to users faster.